### PR TITLE
Fix unused_parens lint

### DIFF
--- a/serde_derive/src/ser.rs
+++ b/serde_derive/src/ser.rs
@@ -870,9 +870,9 @@ fn serialize_struct_variant<'a>(
     }
 
     let struct_trait = match context {
-        StructVariant::ExternallyTagged { .. } => (StructTrait::SerializeStructVariant),
+        StructVariant::ExternallyTagged { .. } => StructTrait::SerializeStructVariant,
         StructVariant::InternallyTagged { .. } | StructVariant::Untagged => {
-            (StructTrait::SerializeStruct)
+            StructTrait::SerializeStruct
         }
     };
 


### PR DESCRIPTION
These are left over from a series of unfortunate rustfmt interactions.
https://github.com/serde-rs/serde/commit/ee75e6c0e9e5cc359163202554feb00a28b62d0d#diff-c052b162f01a664f8184ef1855d1f1cfL767-R735
https://github.com/serde-rs/serde/commit/cc2558b0dc6fd0a40f45c5c5fc3088332b4d6cdf#diff-c052b162f01a664f8184ef1855d1f1cfL733-R738
https://github.com/serde-rs/serde/commit/9f38ca032e0735109adbde10a9f16822a4b975aa#diff-c052b162f01a664f8184ef1855d1f1cfL779-R782