### PR TITLE
Ignore incorrect suggestion from manual_map lint

### DIFF
--- a/serde_derive/src/lib.rs
+++ b/serde_derive/src/lib.rs
@@ -20,6 +20,8 @@
 #![allow(
     clippy::cognitive_complexity,
     clippy::enum_variant_names,
+    // clippy bug: https://github.com/rust-lang/rust-clippy/issues/6797
+    clippy::manual_map,
     clippy::match_like_matches_macro,
     clippy::needless_pass_by_value,
     clippy::too_many_arguments,

--- a/serde_derive_internals/lib.rs
+++ b/serde_derive_internals/lib.rs
@@ -4,6 +4,8 @@
 // Ignored clippy lints
 #![allow(
     clippy::cognitive_complexity,
+    // clippy bug: https://github.com/rust-lang/rust-clippy/issues/6797
+    clippy::manual_map,
     clippy::missing_panics_doc,
     clippy::redundant_field_names,
     clippy::result_unit_err,


### PR DESCRIPTION
https://github.com/rust-lang/rust-clippy/issues/6797

    error[E0382]: use of partially moved value: `self`
       --> serde_derive/src/internals/attr.rs:71:24
        |
    71  |         self.value.map(|value| (self.tokens, value))
        |                    ----^^^^^^^----------------------
        |                    |   |        |
        |                    |   |        use occurs due to use in closure
        |                    |   value used here after partial move
        |                    `self.value` partially moved due to this method call
        |
    note: this function takes ownership of the receiver `self`, which moves `self.value`
       --> /home/david/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/option.rs:485:38
        |
    485 |     pub fn map<U, F: FnOnce(T) -> U>(self, f: F) -> Option<U> {
        |                                      ^^^^
        = note: partial move occurs because `self.value` has type `std::option::Option<T>`, which does not implement the `Copy` trait